### PR TITLE
surface errors back to the calling function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ module.exports = function(emailAddress, cb) {
 	var splitEmail = emailAddress.split('@');
 	dns.resolveMx(splitEmail[1], function(err, addresses){
 		if (addresses) {
-			cb(true, addresses);
+			cb(true, addresses,null);
 		} else {
-			cb(false, null);
+			cb(false, null,err);
 		}
 	});
 };


### PR DESCRIPTION
Surface the errors back to the calling function.
I was using your library so that I could check if email addresses are valid, but at my friend's place due to DNS issues, the `dns.resolveMx(...)` call was timing out for a gmail address.
It might be a good idea to surface this error via the callback so that people using the library can take appropriate action.